### PR TITLE
Update GitHub repository link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ see [reference(archive)](https://web.archive.org/web/20171212085731/http://docs.
 
 ## Download
 
-https://github.com/kanmu/rdslog/releases/latest
+https://github.com/winebarrel/rdslog/releases/latest
 
 ## Usage
 


### PR DESCRIPTION
This pull request updates the download URL in the `README.md` file to point to the correct repository.

- Documentation update:
  * Changed the download link from `kanmu/rdslog` to `winebarrel/rdslog` in `README.md`.